### PR TITLE
Fix: use IThemeRange for chart.background option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -80,7 +80,7 @@ declare namespace tuiChart {
     interface IThemeConfig {
         chart?: {
             fontFamily?: string;
-            background?: string;
+            background?: IThemeRange;
         };
         title?: {
             fontSize?: number;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [X] It's submitted to right branch according to our branching model
- [X] It's right issue type on title
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes/features) -> no need for tests
- [X] Docs have been added/updated (for bug fixes/features) -> already exists
- [X] It does not introduce a breaking change or has description for the breaking change

### Description

I updated the IThemeConfig interface to use the existing IThemeRange interface for the chart.background option. 

The code was already assuming that the option is of type IThemeRange and not just string and also the docs were showing.