### PR TITLE
feat: add heatmap border, spectrum font color options

### DIFF
--- a/src/js/components/legends/spectrumLegend.js
+++ b/src/js/components/legends/spectrumLegend.js
@@ -8,6 +8,7 @@ import isUndefined from 'tui-code-snippet/type/isUndefined';
 import chartConst from '../../const';
 import predicate from '../../helpers/predicate';
 import pluginFactory from '../../factories/pluginFactory';
+import { DEFAULT_LEGEND_LABEL_FONTCOLOR } from '../../themes/defaultTheme';
 
 const {
   COMPONENT_TYPE_RAPHAEL,
@@ -17,6 +18,16 @@ const {
 } = chartConst;
 
 class SpectrumLegend {
+  /**
+   * is default legend label style
+   * @param {string} color label color
+   * @returns {boolean} whether label color style is default
+   * @private
+   */
+  _isDefaultLegendLabelColor(color) {
+    return color === DEFAULT_LEGEND_LABEL_FONTCOLOR;
+  }
+
   /**
    * Spectrum Legend component.
    * @constructs SpectrumLegend
@@ -49,7 +60,7 @@ class SpectrumLegend {
      */
     this.theme = theme;
 
-    if (!predicate.isTreemapChart(this.chartType)) {
+    if (this._isDefaultLegendLabelColor(this.theme.label.color)) {
       this.theme.label.color = '#fff';
     }
 

--- a/src/js/plugins/raphaelBoxTypeChart.js
+++ b/src/js/plugins/raphaelBoxTypeChart.js
@@ -279,7 +279,9 @@ class RaphaelBoxTypeChart {
       return seriesGroup.map((seriesItem, index) => {
         let result = null;
         const { depth } = seriesItem;
-        const strokeWidth = this.colorSpectrum ? 0 : this._getStrokeWidth(depth === startDepth);
+        const strokeWidth = this.colorSpectrum
+          ? this.borderWidth
+          : this._getStrokeWidth(depth === startDepth);
         const fillOpacity = this.colorSpectrum ? 1 : seriesItem.fillOpacity;
 
         seriesItem.groupIndex = groupIndex;

--- a/src/js/themes/defaultTheme.js
+++ b/src/js/themes/defaultTheme.js
@@ -2,6 +2,7 @@ const DEFAULT_COLOR = '#000000';
 const DEFAULT_BACKGROUND = '#ffffff';
 const DEFAULT_FONTWEIGHT = 'lighter';
 const DEFAULT_FONTFAMILY = 'Arial';
+export const DEFAULT_LEGEND_LABEL_FONTCOLOR = '#333';
 const EMPTY = '';
 const DEFAULT_AXIS = {
   tickColor: DEFAULT_COLOR,
@@ -91,7 +92,7 @@ export default {
     label: {
       fontSize: 11,
       fontFamily: DEFAULT_FONTFAMILY,
-      color: '#333',
+      color: DEFAULT_LEGEND_LABEL_FONTCOLOR,
       fontWeight: DEFAULT_FONTWEIGHT
     }
   },


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [ ] It's submitted to right branch according to our branching model
- [ ] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

```js
var theme = {
    series: {
        startColor: '#ffefef',
        endColor: '#ac4142',
        borderColor: '#fff', // heatmap border color
        borderWidth: 2 // heatmap border width
    },
    legend: {
        label: {
            color: 'blue' // heatmap / treemap spectrum font color
        }
    }
};
```
## border / border color 

![image](https://user-images.githubusercontent.com/35371660/79859183-9525a380-840b-11ea-8cb5-781f11651e53.png)

## spectrum color
![image](https://user-images.githubusercontent.com/35371660/79859231-a7074680-840b-11ea-9813-edbb1a4eb5d2.png)



---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨