### PR TITLE
refactor: rename animation models

### DIFF
--- a/src/component/areaSeries.ts
+++ b/src/component/areaSeries.ts
@@ -19,7 +19,7 @@ import { TooltipData } from '@t/components/tooltip';
 import { getCoordinateDataIndex, getCoordinateYValue } from '@src/helpers/coordinate';
 import { getRGBA } from '@src/helpers/color';
 
-type DrawModels = LinePointsModel | AreaPointsModel | ClipRectAreaModel | CircleModel;
+type Models = LinePointsModel | AreaPointsModel | ClipRectAreaModel | CircleModel;
 
 interface RenderOptions {
   pointOnColumn: boolean;
@@ -30,7 +30,7 @@ interface RenderOptions {
 type DatumType = number | RangeDataType;
 
 export default class AreaSeries extends Component {
-  models!: DrawModels[];
+  models!: Models[];
 
   responders!: CircleResponderModel[];
 
@@ -180,7 +180,7 @@ export default class AreaSeries extends Component {
     );
   }
 
-  isAreaPointsModel(model: DrawModels): model is AreaPointsModel {
+  isAreaPointsModel(model: Models): model is AreaPointsModel {
     return model.type === 'areaPoints';
   }
 

--- a/src/component/axis.ts
+++ b/src/component/axis.ts
@@ -10,8 +10,8 @@ export enum AxisType {
   CENTER_Y = 'yCenterAxis',
 }
 
-type DrawModels = LabelModel | TickModel | LineModel;
-type AxisModels = Record<string, DrawModels[]>;
+type Models = LabelModel | TickModel | LineModel;
+type AxisModels = Record<string, Models[]>;
 type CoordinateKey = 'x' | 'y';
 
 interface RenderOptions {
@@ -82,15 +82,15 @@ export default class Axis extends Component {
 
       ['tick', 'label'].forEach((type) => {
         this.models[type] = this.animationTargetModels[type].map((m) => {
-          const drawModel = { ...m };
+          const model = { ...m };
 
           if (this.yAxisComponent) {
-            drawModel.y = 0;
+            model.y = 0;
           } else {
-            drawModel.x = 0;
+            model.x = 0;
           }
 
-          return drawModel;
+          return model;
         });
       });
 

--- a/src/component/axis.ts
+++ b/src/component/axis.ts
@@ -24,9 +24,9 @@ interface RenderOptions {
 export default class Axis extends Component {
   name!: AxisType;
 
-  models: AxisModels = {};
+  animationTargetModels: AxisModels = {};
 
-  drawModels!: AxisModels;
+  models!: AxisModels;
 
   yAxisComponent!: boolean;
 
@@ -60,7 +60,7 @@ export default class Axis extends Component {
       labelInterval,
     };
 
-    this.models.label = this.renderLabelModels(
+    this.animationTargetModels.label = this.renderLabelModels(
       relativePositions,
       !isLabelAxis && this.yAxisComponent ? labels.reverse() : labels,
       offsetKey,
@@ -68,20 +68,20 @@ export default class Axis extends Component {
       renderOptions
     );
 
-    this.models.tick = this.renderTickModels(
+    this.animationTargetModels.tick = this.renderTickModels(
       relativePositions,
       offsetKey,
       anchorKey,
       renderOptions
     );
 
-    this.models.axisLine = [this.renderAxisLineModel()];
+    this.animationTargetModels.axisLine = [this.renderAxisLineModel()];
 
-    if (!this.drawModels) {
-      this.drawModels = {};
+    if (!this.models) {
+      this.models = {};
 
       ['tick', 'label'].forEach((type) => {
-        this.drawModels[type] = this.models[type].map((m) => {
+        this.models[type] = this.animationTargetModels[type].map((m) => {
           const drawModel = { ...m };
 
           if (this.yAxisComponent) {
@@ -94,7 +94,7 @@ export default class Axis extends Component {
         });
       });
 
-      this.drawModels.axisLine = this.models.axisLine;
+      this.models.axisLine = this.animationTargetModels.axisLine;
     }
   }
 

--- a/src/component/boxSeries.ts
+++ b/src/component/boxSeries.ts
@@ -125,7 +125,7 @@ export default class BoxSeries extends Component {
   }
 
   update(delta: number) {
-    if (!this.models) {
+    if (!this.models || !this.animationTargetModels) {
       return;
     }
 

--- a/src/component/boxSeries.ts
+++ b/src/component/boxSeries.ts
@@ -81,9 +81,9 @@ export function isBoxSeries(seriesName: ChartType): seriesName is BoxType {
 }
 
 export default class BoxSeries extends Component {
-  models: DrawModels = { series: [] };
+  animationTargetModels: DrawModels = { series: [] };
 
-  drawModels!: DrawModels;
+  models!: DrawModels;
 
   responders!: RectModel[];
 
@@ -125,15 +125,15 @@ export default class BoxSeries extends Component {
   }
 
   update(delta: number) {
-    if (!this.drawModels) {
+    if (!this.models) {
       return;
     }
 
     const offsetKey = this.isBar ? 'x' : 'y';
-    const { clipRect, series, connector } = this.drawModels;
+    const { clipRect, series, connector } = this.models;
 
     if (this.isRangeData) {
-      const modelSeries = this.models.series;
+      const modelSeries = this.animationTargetModels.series;
 
       series.forEach((drawModel, index) => {
         const targetModel = modelSeries[index];
@@ -156,7 +156,7 @@ export default class BoxSeries extends Component {
     }
 
     if (connector) {
-      const modelConnector = this.models.connector!;
+      const modelConnector = this.animationTargetModels.connector!;
 
       connector.forEach((drawModel, index) => {
         const alpha = getAlpha(modelConnector[index].strokeStyle!) * delta;
@@ -202,12 +202,12 @@ export default class BoxSeries extends Component {
     const tooltipData: TooltipData[] = this.makeTooltipData(seriesData, colors, categories);
     const hoveredSeries = this.renderHighlightSeriesModel(seriesModels);
 
-    this.models.clipRect = [this.renderClipRectAreaModel()];
-    this.models.series = seriesModels;
+    this.animationTargetModels.clipRect = [this.renderClipRectAreaModel()];
+    this.animationTargetModels.series = seriesModels;
 
-    if (!this.drawModels) {
-      this.drawModels = {
-        clipRect: this.models.clipRect,
+    if (!this.models) {
+      this.models = {
+        clipRect: this.animationTargetModels.clipRect,
         series: deepCopyArray(seriesModels),
       };
     }
@@ -304,7 +304,7 @@ export default class BoxSeries extends Component {
   }
 
   onMousemove({ responders }: { responders: RectModel[] }) {
-    this.drawModels.hoveredSeries = responders;
+    this.models.hoveredSeries = responders;
     this.activatedResponders = responders;
 
     this.eventBus.emit('seriesPointHovered', this.activatedResponders);

--- a/src/component/boxSeries.ts
+++ b/src/component/boxSeries.ts
@@ -16,7 +16,7 @@ import { getRGBA, getAlpha } from '@src/helpers/color';
 import { isRangeData, isRangeValue } from '@src/helpers/range';
 import { getLimitOnAxis } from '@src/helpers/axes';
 
-type DrawModels = {
+type Models = {
   clipRect?: ClipRectAreaModel[];
   series: RectModel[];
   hoveredSeries?: RectModel[];
@@ -81,9 +81,9 @@ export function isBoxSeries(seriesName: ChartType): seriesName is BoxType {
 }
 
 export default class BoxSeries extends Component {
-  animationTargetModels: DrawModels = { series: [] };
+  animationTargetModels: Models = { series: [] };
 
-  models!: DrawModels;
+  models!: Models;
 
   responders!: RectModel[];
 

--- a/src/component/boxStackSeries.ts
+++ b/src/component/boxStackSeries.ts
@@ -85,15 +85,15 @@ export default class BoxStackSeries extends BoxSeries {
     const hoveredSeries = this.renderHighlightSeriesModel(series);
     const tooltipData: TooltipData[] = this.getTooltipData(seriesData, colors, categories);
 
-    this.models = {
+    this.animationTargetModels = {
       clipRect: [this.renderClipRectAreaModel()],
       series,
       connector,
     };
 
-    if (!this.drawModels) {
-      this.drawModels = {
-        clipRect: this.models.clipRect,
+    if (!this.models) {
+      this.models = {
+        clipRect: this.animationTargetModels.clipRect,
         series: deepCopyArray(series),
         connector: deepCopyArray(connector),
       };

--- a/src/component/bubbleSeries.ts
+++ b/src/component/bubbleSeries.ts
@@ -54,8 +54,8 @@ export default class BubbleSeries extends CircleSeries {
     const tooltipModel = this.makeTooltipModel(bubbleData, categories, renderOptions);
 
     this.models.series = seriesModel;
-    if (!this.drawModels) {
-      this.drawModels = deepCopy(this.models);
+    if (!this.animationTargetModels) {
+      this.animationTargetModels = deepCopy(this.models);
     }
     this.responders = seriesModel.map((m, index) => ({
       ...m,

--- a/src/component/circleSeries.ts
+++ b/src/component/circleSeries.ts
@@ -9,9 +9,9 @@ type CircleSeriesModels = {
 };
 
 export default abstract class CircleSeries extends Component {
-  models: CircleSeriesModels = { series: [], hoveredSeries: [] };
+  animationTargetModels: CircleSeriesModels = { series: [], hoveredSeries: [] };
 
-  drawModels!: CircleSeriesModels;
+  models!: CircleSeriesModels;
 
   responders!: CircleResponderModel[];
 
@@ -20,8 +20,8 @@ export default abstract class CircleSeries extends Component {
   rect!: Rect;
 
   update(delta: number) {
-    this.drawModels.series.forEach((model, index) => {
-      model.radius = (this.models.series[index] as CircleModel).radius * delta;
+    this.models.series.forEach((model, index) => {
+      model.radius = (this.animationTargetModels.series[index] as CircleModel).radius * delta;
     });
   }
 
@@ -46,7 +46,7 @@ export default abstract class CircleSeries extends Component {
 
   onMousemove({ responders, mousePosition }) {
     const closestResponder = this.getClosestResponder(responders, mousePosition);
-    this.drawModels.hoveredSeries = closestResponder;
+    this.models.hoveredSeries = closestResponder;
     this.activatedResponders = closestResponder;
 
     this.eventBus.emit('seriesPointHovered', this.activatedResponders);

--- a/src/component/circleSeries.ts
+++ b/src/component/circleSeries.ts
@@ -9,9 +9,9 @@ type CircleSeriesModels = {
 };
 
 export default abstract class CircleSeries extends Component {
-  animationTargetModels: CircleSeriesModels = { series: [], hoveredSeries: [] };
+  models: CircleSeriesModels = { series: [], hoveredSeries: [] };
 
-  models!: CircleSeriesModels;
+  animationTargetModels!: CircleSeriesModels;
 
   responders!: CircleResponderModel[];
 

--- a/src/component/component.ts
+++ b/src/component/component.ts
@@ -40,10 +40,6 @@ export default abstract class Component {
   abstract render(state: ChartState<Options>, computed: Record<string, any>): void;
 
   update(delta: number) {
-    // if (!this.models) {
-    //   return;
-    // }
-
     if (!this.animationTargetModels || !this.models) {
       return;
     }

--- a/src/component/component.ts
+++ b/src/component/component.ts
@@ -24,9 +24,9 @@ export default abstract class Component {
 
   eventBus: EventEmitter;
 
-  models!: any; // @TODO: 정의
+  animationTargetModels!: any; // @TODO: 정의
 
-  drawModels!: any; // @TODO: 정의
+  models!: any; // @TODO: 정의
 
   responders!: any[]; // @TODO: 정의
 
@@ -40,16 +40,16 @@ export default abstract class Component {
   abstract render(state: ChartState<Options>, computed: Record<string, any>): void;
 
   update(delta: number) {
-    if (!this.drawModels) {
+    if (!this.animationTargetModels) {
       return;
     }
 
-    if (Array.isArray(this.models)) {
-      this.updateModels(this.drawModels, this.models, delta);
+    if (Array.isArray(this.animationTargetModels)) {
+      this.updateModels(this.models, this.animationTargetModels, delta);
     } else {
-      Object.keys(this.models).forEach((type) => {
-        const currentModels = this.drawModels[type];
-        const targetModels = this.models[type];
+      Object.keys(this.animationTargetModels).forEach((type) => {
+        const currentModels = this.models[type];
+        const targetModels = this.animationTargetModels[type];
 
         this.updateModels(currentModels, targetModels, delta);
       });
@@ -75,16 +75,16 @@ export default abstract class Component {
   }
 
   sync() {
-    if (!this.drawModels) {
+    if (!this.animationTargetModels) {
       return;
     }
 
-    if (Array.isArray(this.models)) {
-      this.syncModels(this.drawModels, this.models);
+    if (Array.isArray(this.animationTargetModels)) {
+      this.syncModels(this.models, this.animationTargetModels);
     } else {
-      Object.keys(this.models).forEach((type) => {
-        const currentModels = this.drawModels[type];
-        const targetModels = this.models[type];
+      Object.keys(this.animationTargetModels).forEach((type) => {
+        const currentModels = this.models[type];
+        const targetModels = this.animationTargetModels[type];
 
         this.syncModels(currentModels, targetModels, type);
       });
@@ -92,7 +92,7 @@ export default abstract class Component {
   }
 
   syncModels(currentModels, targetModels, type?: string) {
-    const drawModels = type ? this.drawModels[type] : this.drawModels;
+    const drawModels = type ? this.models[type] : this.models;
 
     if (currentModels.length < targetModels.length) {
       drawModels.splice(
@@ -112,7 +112,7 @@ export default abstract class Component {
   onMousemove?(responseData: any): void;
 
   draw(painter: Painter) {
-    const models = this.drawModels ? this.drawModels : this.models;
+    const models = this.models ? this.models : this.animationTargetModels;
 
     if (Array.isArray(models)) {
       painter.paintForEach(models);

--- a/src/component/component.ts
+++ b/src/component/component.ts
@@ -40,7 +40,7 @@ export default abstract class Component {
   abstract render(state: ChartState<Options>, computed: Record<string, any>): void;
 
   update(delta: number) {
-    if (!this.animationTargetModels) {
+    if (!this.models) {
       return;
     }
 
@@ -75,7 +75,7 @@ export default abstract class Component {
   }
 
   sync() {
-    if (!this.animationTargetModels) {
+    if (!this.models) {
       return;
     }
 

--- a/src/component/component.ts
+++ b/src/component/component.ts
@@ -92,16 +92,16 @@ export default abstract class Component {
   }
 
   syncModels(currentModels, targetModels, type?: string) {
-    const drawModels = type ? this.models[type] : this.models;
+    const models = type ? this.models[type] : this.models;
 
     if (currentModels.length < targetModels.length) {
-      drawModels.splice(
+      models.splice(
         currentModels.length,
         0,
         ...targetModels.slice(currentModels.length, targetModels.length)
       );
     } else if (currentModels.length > targetModels.length) {
-      drawModels.splice(targetModels.length, currentModels.length);
+      models.splice(targetModels.length, currentModels.length);
     }
   }
 
@@ -112,7 +112,7 @@ export default abstract class Component {
   onMousemove?(responseData: any): void;
 
   draw(painter: Painter) {
-    const models = this.models;
+    const { models } = this;
 
     if (Array.isArray(models)) {
       painter.paintForEach(models);

--- a/src/component/component.ts
+++ b/src/component/component.ts
@@ -40,7 +40,11 @@ export default abstract class Component {
   abstract render(state: ChartState<Options>, computed: Record<string, any>): void;
 
   update(delta: number) {
-    if (!this.models) {
+    // if (!this.models) {
+    //   return;
+    // }
+
+    if (!this.animationTargetModels || !this.models) {
       return;
     }
 
@@ -75,7 +79,7 @@ export default abstract class Component {
   }
 
   sync() {
-    if (!this.models) {
+    if (!this.animationTargetModels || !this.models) {
       return;
     }
 
@@ -112,7 +116,7 @@ export default abstract class Component {
   onMousemove?(responseData: any): void;
 
   draw(painter: Painter) {
-    const models = this.models ? this.models : this.animationTargetModels;
+    const models = this.models;
 
     if (Array.isArray(models)) {
       painter.paintForEach(models);

--- a/src/component/componentManager.ts
+++ b/src/component/componentManager.ts
@@ -39,7 +39,7 @@ export default class ComponentManager<T> {
 
     let proc = (...args: any[]) => {
       component.render(args[0], args[1]); // rest쓰면 에러남
-      component.sync();
+      // component.sync(); // render 에서 animationTargetModels 와 models 를 조작하기 떄문에 목적이 불분명
       this.eventBus.emit('needLoop');
     };
 

--- a/src/component/lineSeries.ts
+++ b/src/component/lineSeries.ts
@@ -8,7 +8,7 @@ import { getValueRatio, setSplineControlPoint } from '@src/helpers/calculator';
 import { TooltipData } from '@t/components/tooltip';
 import { getCoordinateDataIndex, getCoordinateYValue } from '@src/helpers/coordinate';
 
-type DrawModels = LinePointsModel | ClipRectAreaModel | CircleModel;
+type Models = LinePointsModel | ClipRectAreaModel | CircleModel;
 
 interface RenderLineOptions {
   pointOnColumn: boolean;
@@ -19,7 +19,7 @@ interface RenderLineOptions {
 type DatumType = CoordinateDataType | number;
 
 export default class LineSeries extends Component {
-  models!: DrawModels[];
+  models!: Models[];
 
   responders!: CircleResponderModel[];
 

--- a/src/component/plot.ts
+++ b/src/component/plot.ts
@@ -5,7 +5,7 @@ import Painter from '@src/painter';
 import { LineModel } from '@t/components/axis';
 
 export default class Plot extends Component {
-  models: Record<string, LineModel[]> = {};
+  animationTargetModels: Record<string, LineModel[]> = {};
 
   initialize() {
     this.type = 'plot';
@@ -39,13 +39,13 @@ export default class Plot extends Component {
   render({ layout, axes, plot }: ChartState<Options>) {
     this.rect = layout.plot;
 
-    this.models.plot = [
+    this.animationTargetModels.plot = [
       ...this.renderModels(this.getTickPixelPositions(false, axes), false),
       ...this.renderModels(this.getTickPixelPositions(true, axes), true),
     ];
 
     if (plot) {
-      this.models.lines = [...this.renderLines(plot.lines!, axes)];
+      this.animationTargetModels.lines = [...this.renderLines(plot.lines!, axes)];
     }
   }
 

--- a/src/component/plot.ts
+++ b/src/component/plot.ts
@@ -5,7 +5,7 @@ import Painter from '@src/painter';
 import { LineModel } from '@t/components/axis';
 
 export default class Plot extends Component {
-  animationTargetModels: Record<string, LineModel[]> = {};
+  models: Record<string, LineModel[]> = {};
 
   initialize() {
     this.type = 'plot';
@@ -39,13 +39,13 @@ export default class Plot extends Component {
   render({ layout, axes, plot }: ChartState<Options>) {
     this.rect = layout.plot;
 
-    this.animationTargetModels.plot = [
+    this.models.plot = [
       ...this.renderModels(this.getTickPixelPositions(false, axes), false),
       ...this.renderModels(this.getTickPixelPositions(true, axes), true),
     ];
 
     if (plot) {
-      this.animationTargetModels.lines = [...this.renderLines(plot.lines!, axes)];
+      this.models.lines = [...this.renderLines(plot.lines!, axes)];
     }
   }
 

--- a/src/component/scatterSeries.ts
+++ b/src/component/scatterSeries.ts
@@ -34,9 +34,9 @@ export default class ScatterSeries extends CircleSeries {
     const seriesModel = this.renderScatterPointsModel(scatterData, scale, renderOptions);
     const tooltipModel = this.makeTooltipModel(scatterData, categories, renderOptions);
 
-    this.animationTargetModels.series = seriesModel;
-    if (!this.models) {
-      this.models = deepCopy(this.animationTargetModels);
+    this.models.series = seriesModel;
+    if (!this.animationTargetModels) {
+      this.animationTargetModels = deepCopy(this.models);
     }
     this.responders = seriesModel.map((m, index) => ({
       ...m,

--- a/src/component/scatterSeries.ts
+++ b/src/component/scatterSeries.ts
@@ -34,9 +34,9 @@ export default class ScatterSeries extends CircleSeries {
     const seriesModel = this.renderScatterPointsModel(scatterData, scale, renderOptions);
     const tooltipModel = this.makeTooltipModel(scatterData, categories, renderOptions);
 
-    this.models.series = seriesModel;
-    if (!this.drawModels) {
-      this.drawModels = deepCopy(this.models);
+    this.animationTargetModels.series = seriesModel;
+    if (!this.models) {
+      this.models = deepCopy(this.animationTargetModels);
     }
     this.responders = seriesModel.map((m, index) => ({
       ...m,

--- a/src/component/tooltip.ts
+++ b/src/component/tooltip.ts
@@ -6,6 +6,8 @@ import { TooltipInfo, TooltipModel } from '@t/components/tooltip';
 export default class Tooltip extends Component {
   models!: TooltipModel[];
 
+  animationTargetModels!: TooltipModel[];
+
   isShow = false;
 
   needLoop!: () => void;

--- a/src/component/tooltip.ts
+++ b/src/component/tooltip.ts
@@ -21,7 +21,7 @@ export default class Tooltip extends Component {
   renderTooltip(tooltipInfos: TooltipInfo[]) {
     let maxLength = 0;
 
-    this.models = [
+    this.animationTargetModels = [
       tooltipInfos.reduce<TooltipModel>(
         (acc, item) => {
           const { data } = item;
@@ -51,8 +51,8 @@ export default class Tooltip extends Component {
       ),
     ];
 
-    if (!this.drawModels) {
-      this.drawModels = [{ ...this.models[0] }];
+    if (!this.models) {
+      this.models = [{ ...this.animationTargetModels[0] }];
     } else {
       this.needLoop();
     }
@@ -78,6 +78,6 @@ export default class Tooltip extends Component {
 
   render({ layout }: ChartState<Options>) {
     this.rect = layout.plot;
-    this.models = [];
+    this.animationTargetModels = [];
   }
 }

--- a/src/component/tooltip.ts
+++ b/src/component/tooltip.ts
@@ -6,7 +6,7 @@ import { TooltipInfo, TooltipModel } from '@t/components/tooltip';
 export default class Tooltip extends Component {
   models!: TooltipModel[];
 
-  animationTargetModels!: TooltipModel[];
+  animationTargetModels: TooltipModel[] = [];
 
   isShow = false;
 

--- a/tests/components/axes.spec.ts
+++ b/tests/components/axes.spec.ts
@@ -33,14 +33,14 @@ describe('yAxis', () => {
     });
 
     it('tick model', () => {
-      expect(axis.models.tick).toEqual([
+      expect(axis.animationTargetModels.tick).toEqual([
         { isYAxis: true, type: 'tick', x: 10.5, y: 0.5 },
         { isYAxis: true, type: 'tick', x: 10.5, y: 80.5 },
       ]);
     });
 
     it('label model', () => {
-      expect(axis.models.label).toEqual([
+      expect(axis.animationTargetModels.label).toEqual([
         {
           style: ['default', { textAlign: 'left' }],
           text: '2',
@@ -59,7 +59,9 @@ describe('yAxis', () => {
     });
 
     it('axisLine', () => {
-      expect(axis.models.axisLine).toEqual([{ type: 'line', x: 10.5, x2: 10.5, y: 0.5, y2: 80.5 }]);
+      expect(axis.animationTargetModels.axisLine).toEqual([
+        { type: 'line', x: 10.5, x2: 10.5, y: 0.5, y2: 80.5 },
+      ]);
     });
   });
 
@@ -117,14 +119,14 @@ describe('xAxis', () => {
     });
 
     it('tick model', () => {
-      expect(axis.models.tick).toEqual([
+      expect(axis.animationTargetModels.tick).toEqual([
         { isYAxis: false, type: 'tick', x: 0.5, y: 0.5 },
         { isYAxis: false, type: 'tick', x: 80.5, y: 0.5 },
       ]);
     });
 
     it('label model', () => {
-      expect(axis.models.label).toEqual([
+      expect(axis.animationTargetModels.label).toEqual([
         {
           style: ['default', { textAlign: 'center' }],
           text: '1',
@@ -143,7 +145,9 @@ describe('xAxis', () => {
     });
 
     it('axisLine', () => {
-      expect(axis.models.axisLine).toEqual([{ type: 'line', x: 0.5, x2: 80.5, y: 0.5, y2: 0.5 }]);
+      expect(axis.animationTargetModels.axisLine).toEqual([
+        { type: 'line', x: 0.5, x2: 80.5, y: 0.5, y2: 0.5 },
+      ]);
     });
   });
 
@@ -165,11 +169,11 @@ describe('xAxis', () => {
     });
 
     it('tick interval option apply the number of tick model', () => {
-      expect(axis.models.tick).toHaveLength(5);
+      expect(axis.animationTargetModels.tick).toHaveLength(5);
     });
 
     it('label interval option apply the number of label model', () => {
-      expect(axis.models.label).toHaveLength(5);
+      expect(axis.animationTargetModels.label).toHaveLength(5);
     });
   });
 });


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [ ] It's submitted to right branch according to our branching model
- [ ] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

* `models`, `drawModels`에서 `models`, `animationTargetModels`로 변경

* 항상 `models`를 기준으로 draw를 한다.
* 애니메이션이 끝날 경우 `animationTargetModels`와 `models`는 같은 값을 가진다.
* 현재 구조에서는 `sync`메서드의 역할이 없어보임
    * render 함수에서 models와 animationTargetModels를 조작하기 때문
* models를 조작하는 부분을 최소화하고 animationTargetModels와 models를 항상 sync 맞춰 주기 위한 함수 필요


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨