### PR TITLE
feat: store module setup interface changed and extract category module

### DIFF
--- a/src/charts/areaChart.ts
+++ b/src/charts/areaChart.ts
@@ -21,6 +21,8 @@ interface AreaChartProps {
 }
 
 export default class AreaChart extends Chart<AreaChartOptions> {
+  modules = [dataRange, scale, axes];
+
   constructor(props: AreaChartProps) {
     super({
       el: props.el,
@@ -34,10 +36,6 @@ export default class AreaChart extends Chart<AreaChartOptions> {
 
   initialize() {
     super.initialize();
-
-    this.store.setModule(dataRange);
-    this.store.setModule(scale);
-    this.store.setModule(axes);
 
     this.componentManager.add(Plot);
     this.componentManager.add(Axis, { name: 'yAxis' });

--- a/src/charts/barChart.ts
+++ b/src/charts/barChart.ts
@@ -29,6 +29,8 @@ interface BarChartProps {
 }
 
 export default class BarChart extends Chart<BarChartOptions> {
+  modules = [stackSeriesData, dataRange, scale, axes, plot];
+
   constructor({ el, options, data }: BarChartProps) {
     super({
       el,
@@ -42,12 +44,6 @@ export default class BarChart extends Chart<BarChartOptions> {
 
   initialize() {
     super.initialize();
-
-    this.store.setModule(stackSeriesData);
-    this.store.setModule(dataRange);
-    this.store.setModule(scale);
-    this.store.setModule(axes);
-    this.store.setModule(plot);
 
     this.componentManager.add(Plot);
     this.componentManager.add(Axis, { name: 'yAxis' });

--- a/src/charts/bubbleChart.ts
+++ b/src/charts/bubbleChart.ts
@@ -20,6 +20,8 @@ interface BubbleChartProps {
 }
 
 export default class BubbleChart extends Chart<BaseOptions> {
+  modules = [dataRange, scale, axes];
+
   constructor(props: BubbleChartProps) {
     super({
       el: props.el,
@@ -32,10 +34,6 @@ export default class BubbleChart extends Chart<BaseOptions> {
 
   initialize() {
     super.initialize();
-
-    this.store.setModule(dataRange);
-    this.store.setModule(scale);
-    this.store.setModule(axes);
 
     this.componentManager.add(BubbleSeries);
     this.componentManager.add(Axis, { name: 'yAxis' });

--- a/src/charts/chart.ts
+++ b/src/charts/chart.ts
@@ -11,8 +11,9 @@ import { debounce } from '@src/helpers/utils';
 import { ChartProps } from '@t/options';
 import { responderDetectors } from '@src/responderDetectors';
 import { Options } from '@t/store/store';
+import Tooltip from '@src/component/tooltip';
 
-export default class Chart<T extends Options> {
+export default abstract class Chart<T extends Options> {
   store: Store<T>;
 
   ___animId___ = null;
@@ -38,12 +39,12 @@ export default class Chart<T extends Options> {
       options,
     });
 
+    this.initStore();
+
     this.componentManager = new ComponentManager({
       store: this.store,
       eventBus: this.eventBus,
     });
-
-    this.initialize();
 
     this.store.observe(() => {
       this.painter.setup();
@@ -75,6 +76,8 @@ export default class Chart<T extends Options> {
         this.draw();
       }, 10)
     );
+
+    this.initialize();
   }
 
   handleEvent(event: MouseEvent) {
@@ -106,11 +109,15 @@ export default class Chart<T extends Options> {
     });
   }
 
-  initialize() {
+  initStore() {
     this.store.setModule(root);
     this.store.setModule(layout);
     this.store.setModule(seriesData);
     this.store.setModule(category);
+  }
+
+  initialize() {
+    this.componentManager.add(Tooltip);
   }
 
   draw() {
@@ -131,6 +138,7 @@ export default class Chart<T extends Options> {
   }
 
   update(delta: number) {
+    console.log('update');
     this.componentManager.invoke('update', delta);
   }
 }

--- a/src/charts/chart.ts
+++ b/src/charts/chart.ts
@@ -1,4 +1,5 @@
 import Store from '@src/store/store';
+import root from '@src/store/root';
 import layout from '@src/store/layout';
 import seriesData from '@src/store/seriesData';
 import EventEmitter from '@src/eventEmitter';
@@ -105,6 +106,7 @@ export default class Chart<T extends Options> {
   }
 
   initialize() {
+    this.store.setModule(root);
     this.store.setModule(layout);
     this.store.setModule(seriesData);
   }

--- a/src/charts/chart.ts
+++ b/src/charts/chart.ts
@@ -2,6 +2,7 @@ import Store from '@src/store/store';
 import root from '@src/store/root';
 import layout from '@src/store/layout';
 import seriesData from '@src/store/seriesData';
+import category from '@src/store/category';
 import EventEmitter from '@src/eventEmitter';
 import ComponentManager from '@src/component/componentManager';
 import Painter from '@src/painter';
@@ -42,6 +43,8 @@ export default class Chart<T extends Options> {
       eventBus: this.eventBus,
     });
 
+    this.initialize();
+
     this.store.observe(() => {
       this.painter.setup();
     });
@@ -72,8 +75,6 @@ export default class Chart<T extends Options> {
         this.draw();
       }, 10)
     );
-
-    this.initialize();
   }
 
   handleEvent(event: MouseEvent) {
@@ -109,6 +110,7 @@ export default class Chart<T extends Options> {
     this.store.setModule(root);
     this.store.setModule(layout);
     this.store.setModule(seriesData);
+    this.store.setModule(category);
   }
 
   draw() {

--- a/src/charts/columnChart.ts
+++ b/src/charts/columnChart.ts
@@ -26,6 +26,8 @@ interface ColumnChartProps {
 }
 
 export default class ColumnChart extends Chart<ColumnChartOptions> {
+  modules = [stackSeriesData, dataRange, scale, axes, plot];
+
   constructor({ el, options, data }: ColumnChartProps) {
     super({
       el,
@@ -39,12 +41,6 @@ export default class ColumnChart extends Chart<ColumnChartOptions> {
 
   initialize() {
     super.initialize();
-
-    this.store.setModule(stackSeriesData);
-    this.store.setModule(dataRange);
-    this.store.setModule(scale);
-    this.store.setModule(axes);
-    this.store.setModule(plot);
 
     this.componentManager.add(Plot);
     this.componentManager.add(Axis, { name: 'xAxis' });

--- a/src/charts/lineChart.ts
+++ b/src/charts/lineChart.ts
@@ -21,6 +21,8 @@ interface LineChartProps {
 }
 
 export default class LineChart extends Chart<LineChartOptions> {
+  modules = [dataRange, scale, axes];
+
   constructor(props: LineChartProps) {
     super({
       el: props.el,
@@ -34,10 +36,6 @@ export default class LineChart extends Chart<LineChartOptions> {
 
   initialize() {
     super.initialize();
-
-    this.store.setModule(dataRange);
-    this.store.setModule(scale);
-    this.store.setModule(axes);
 
     this.componentManager.add(Plot);
     this.componentManager.add(LineSeries);

--- a/src/charts/scatterChart.ts
+++ b/src/charts/scatterChart.ts
@@ -21,6 +21,8 @@ interface ScatterChartProps {
 }
 
 export default class ScatterChart extends Chart<ScatterChartOptions> {
+  modules = [dataRange, scale, axes];
+
   constructor(props: ScatterChartProps) {
     super({
       el: props.el,
@@ -34,10 +36,6 @@ export default class ScatterChart extends Chart<ScatterChartOptions> {
 
   initialize() {
     super.initialize();
-
-    this.store.setModule(dataRange);
-    this.store.setModule(scale);
-    this.store.setModule(axes);
 
     this.componentManager.add(Plot);
     this.componentManager.add(ScatterSeries);

--- a/src/store/category.ts
+++ b/src/store/category.ts
@@ -1,0 +1,26 @@
+import { StoreModule, SeriesRaw } from '@t/store/store';
+
+import { sortCategories } from '@src/helpers/utils';
+
+function makeCategories(series: SeriesRaw) {
+  const categories: Set<string> = new Set();
+
+  Object.keys(series).forEach((key) => {
+    series[key].forEach(({ data }) => {
+      data.forEach((datum) => {
+        categories.add(Array.isArray(datum) ? String(datum[0]) : String(datum.x));
+      });
+    });
+  });
+
+  return Array.from(categories).sort(sortCategories);
+}
+
+const category: StoreModule = {
+  name: 'category',
+  state: ({ series, categories }) => ({
+    categories: categories ? categories : makeCategories(series),
+  }),
+};
+
+export default category;

--- a/src/store/root.ts
+++ b/src/store/root.ts
@@ -7,7 +7,6 @@ const root: StoreModule = {
   state: ({ options }) => ({
     chart: options.chart ?? { width: 0, height: 0 },
     options,
-    disabledSeries: [],
     theme: {
       series: {
         colors: [

--- a/src/store/seriesData.ts
+++ b/src/store/seriesData.ts
@@ -1,22 +1,7 @@
 import { StoreModule, SeriesTypes, SeriesRaw, Series } from '@t/store/store';
 import { extend } from '@src/store/store';
 
-import { sortSeries, sortCategories, includes } from '@src/helpers/utils';
-import { line } from '@src/brushes/basic';
-
-function makeCategories(series: SeriesRaw) {
-  const categories: Set<string> = new Set();
-
-  Object.keys(series).forEach((key) => {
-    series[key].forEach(({ data }) => {
-      data.forEach((datum) => {
-        categories.add(Array.isArray(datum) ? String(datum[0]) : String(datum.x));
-      });
-    });
-  });
-
-  return Array.from(categories).sort(sortCategories);
-}
+import { sortSeries } from '@src/helpers/utils';
 
 function makeInitSeries(series: SeriesRaw) {
   const result: Series = {};
@@ -36,12 +21,11 @@ function makeInitSeries(series: SeriesRaw) {
   return result;
 }
 
-// seriesDataModel 이 했던것 일부 여기로
 const seriesData: StoreModule = {
   name: 'seriesData',
-  state: ({ series, categories }) => ({
+  state: ({ series }) => ({
     series: makeInitSeries(series),
-    categories: categories ? categories : makeCategories(series),
+    disabledSeries: [],
   }),
   action: {
     setSeriesData({ state }) {

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -22,8 +22,6 @@ import {
 
 import { isUndefined, forEach, pickPropertyWithMakeup, deepCopy } from '@src/helpers/utils';
 
-import root from '@src/store/root';
-
 export default class Store<T extends Options> {
   state!: ChartState<T>;
 
@@ -37,7 +35,6 @@ export default class Store<T extends Options> {
     this.initStoreState = deepCopy(initStoreState);
 
     this.setRootState({});
-    this.setModule(root);
   }
 
   setRootState(state: Partial<ChartState<T>>) {

--- a/tests/store/category.spec.ts
+++ b/tests/store/category.spec.ts
@@ -1,0 +1,64 @@
+import category from '@src/store/category';
+import { StateFunc } from '@t/store/store';
+
+describe('Category Store', () => {
+  describe('state', () => {
+    it('should make categories from param', () => {
+      const state = (category.state as StateFunc)({
+        categories: ['a', 'b', 'c'],
+        options: {},
+        series: {},
+      });
+
+      expect(state.categories).toEqual(['a', 'b', 'c']);
+    });
+
+    it('should make categories with coordinate data', () => {
+      let state = (category.state as StateFunc)({
+        options: {
+          chart: {
+            width: 1,
+            height: 2,
+          },
+        },
+        series: {
+          line: [
+            {
+              name: 'test',
+              data: [
+                { x: 10, y: 5 },
+                { x: 1, y: 2 },
+                { x: 3, y: 5 },
+              ],
+            },
+          ],
+        },
+      });
+
+      expect(state.categories).toEqual(['1', '3', '10']);
+
+      state = (category.state as StateFunc)({
+        options: {
+          chart: {
+            width: 1,
+            height: 2,
+          },
+        },
+        series: {
+          line: [
+            {
+              name: 'test',
+              data: [
+                [10, 5],
+                [1, 2],
+                [3, 5],
+              ],
+            },
+          ],
+        },
+      });
+
+      expect(state.categories).toEqual(['1', '3', '10']);
+    });
+  });
+});

--- a/tests/store/root.spec.ts
+++ b/tests/store/root.spec.ts
@@ -1,0 +1,81 @@
+import root from '@src/store/root';
+import { StateFunc } from '@t/store/store';
+
+describe('Root store', () => {
+  describe('state', () => {
+    it('could make default states', () => {
+      const state = (root.state as StateFunc)({ options: {} } as any);
+
+      expect(state).toEqual({
+        chart: { width: 0, height: 0 },
+        options: {},
+        theme: {
+          series: {
+            colors: [
+              '#00a9ff',
+              '#ffb840',
+              '#ff5a46',
+              '#00bd9f',
+              '#785fff',
+              '#f28b8c',
+              '#989486',
+              '#516f7d',
+              '#29dbe3',
+              '#dddddd',
+            ],
+          },
+        },
+      });
+    });
+
+    it('should make states chart option', () => {
+      const state = (root.state as StateFunc)({
+        options: { chart: { width: 1, height: 2 } },
+      } as any);
+
+      expect(state.chart).toEqual({ width: 1, height: 2 });
+    });
+  });
+
+  describe('action', () => {
+    describe('initChartSize', () => {
+      it('should setup chart size if container has attached', () => {
+        const dispatch = jest.fn();
+
+        root.action!.initChartSize.call(
+          { dispatch },
+          { state: { chart: { width: 0, height: 0 } } } as any,
+          {
+            parentNode: {},
+            offsetWidth: 1,
+            offsetHeight: 2,
+          }
+        );
+
+        expect(dispatch.mock.calls[0]).toEqual(['setChartSize', { width: 1, height: 2 }]);
+      });
+
+      it('could be wait one frame expect for container has been attached to get chart size', () => {
+        const dispatch = jest.fn();
+
+        jest.useFakeTimers();
+
+        root.action!.initChartSize.call(
+          { dispatch },
+          { state: { chart: { width: 0, height: 0 } } } as any,
+          {
+            parentNode: null,
+            offsetWidth: 1,
+            offsetHeight: 2,
+          }
+        );
+
+        jest.advanceTimersByTime(0);
+
+        jest.clearAllTimers();
+
+        expect(dispatch.mock.calls[0]).toEqual(['setChartSize', { width: 1, height: 2 }]);
+      });
+    });
+  });
+});

--- a/tests/store/seriesData.spec.ts
+++ b/tests/store/seriesData.spec.ts
@@ -1,0 +1,7 @@
+// import seriesData from '@src/store/seriesData';
+
+describe('SeriesData store', () => {
+  it('TODO 우선 파일만 만들었어요 나중에 모듈 변경있을때 TC도 추가 해주세요', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/tests/store/store.spec.ts
+++ b/tests/store/store.spec.ts
@@ -6,15 +6,10 @@ describe('Store', () => {
 
   describe('Computed', () => {
     beforeEach(() => {
-      store = new Store({
-        options: {
-          chart: {
-            width: 1,
-            height: 2,
-          },
-        },
-        categories: [],
-        series: {},
+      store = new Store({} as any);
+
+      store.setRootState({
+        chart: { width: 1, height: 2 },
       });
     });
     it('should computed property correctly', () => {
@@ -28,15 +23,10 @@ describe('Store', () => {
 
   describe('Observe', () => {
     beforeEach(() => {
-      store = new Store({
-        options: {
-          chart: {
-            width: 1,
-            height: 2,
-          },
-        },
-        categories: [],
-        series: {},
+      store = new Store({} as any);
+
+      store.setRootState({
+        chart: { width: 1, height: 2 },
       });
     });
     it('should observe observable correctly', () => {
@@ -67,15 +57,10 @@ describe('Store', () => {
 
   describe('watcher', () => {
     beforeEach(() => {
-      store = new Store({
-        options: {
-          chart: {
-            width: 1,
-            height: 2,
-          },
-        },
-        categories: [],
-        series: {},
+      store = new Store({} as any);
+
+      store.setRootState({
+        chart: { width: 1, height: 2 },
       });
     });
     it('should watcher property correctly', () => {
@@ -184,15 +169,10 @@ describe('Store', () => {
 
   describe('Action', () => {
     beforeEach(() => {
-      store = new Store({
-        options: {
-          chart: {
-            width: 1,
-            height: 2,
-          },
-        },
-        categories: [],
-        series: {},
+      store = new Store({} as any);
+
+      store.setRootState({
+        chart: { width: 1, height: 2 },
       });
     });
 
@@ -207,31 +187,21 @@ describe('Store', () => {
     });
   });
 
-  it('should make state correctly', () => {
-    store = new Store({
-      options: {
-        chart: {
-          width: 1,
-          height: 2,
-        },
-      },
-      categories: [],
-      series: {},
+  it('should make state correctly with setRootState()', () => {
+    store = new Store({} as any);
+
+    store.setRootState({
+      chart: { width: 1, height: 2 },
     });
 
-    expect(store.state.chart.width).toEqual(1);
+    expect(store.state).toEqual({ chart: { width: 1, height: 2 } });
   });
 
   it('should notify observable dependencies by name path', () => {
-    store = new Store({
-      options: {
-        chart: {
-          width: 1,
-          height: 2,
-        },
-      },
-      categories: [],
-      series: {},
+    store = new Store({} as any);
+
+    store.setRootState({
+      chart: { width: 1, height: 2 },
     });
 
     let makeMyData = 0;
@@ -246,15 +216,10 @@ describe('Store', () => {
   });
 
   it('should notify observable dependencies', () => {
-    store = new Store({
-      options: {
-        chart: {
-          width: 1,
-          height: 2,
-        },
-      },
-      categories: [],
-      series: {},
+    store = new Store({} as any);
+
+    store.setRootState({
+      chart: { width: 1, height: 2 },
     });
 
     let makeMyData = 0;
@@ -266,53 +231,5 @@ describe('Store', () => {
     store.notify(store.state.chart, 'width');
 
     expect(makeMyData).toEqual(2);
-  });
-
-  it.skip('should make categories with coordinate data', () => {
-    store = new Store({
-      options: {
-        chart: {
-          width: 1,
-          height: 2,
-        },
-      },
-      series: {
-        line: [
-          {
-            name: 'test',
-            data: [
-              { x: 10, y: 5 },
-              { x: 1, y: 2 },
-              { x: 3, y: 5 },
-            ],
-          },
-        ],
-      },
-    });
-
-    expect(store.state.categories).toEqual(['1', '3', '10']);
-
-    store = new Store({
-      options: {
-        chart: {
-          width: 1,
-          height: 2,
-        },
-      },
-      series: {
-        line: [
-          {
-            name: 'test',
-            data: [
-              [10, 5],
-              [1, 2],
-              [3, 5],
-            ],
-          },
-        ],
-      },
-    });
-
-    expect(store.state.categories).toEqual(['1', '3', '10']);
   });
 });

--- a/types/store/store.d.ts
+++ b/types/store/store.d.ts
@@ -87,6 +87,7 @@ export interface StoreModule extends StoreOptions {
     | 'axes'
     | 'scale'
     | 'layout'
+    | 'category'
     | 'seriesData'
     | 'dataRange'
     | 'stackSeriesData';


### PR DESCRIPTION
- extract category module.
- some related codes fixed.
- add tcs and modified.
- store module setup interface changed
  - Use `modules` property of chart instead.
    ```typescript
    initialize() {
        this.store.setModule(module1);
        this.store.setModule(module2);
        ...
    }
    ```
     to
     ```typescript
     class barChart extends Chart {
        modules = [modules1, modules2]
        ...
     }
     ```

  - we can change whole module setup order (includes default modules) by overriding `Chart.initStore(defaultModules[])`