### PR TITLE
feat: set init animation duration by options

### DIFF
--- a/src/animator.ts
+++ b/src/animator.ts
@@ -1,5 +1,6 @@
 import Chart from './charts/chart';
 import { Options } from '@t/store/store';
+import { isNull } from '@src/helpers/utils';
 
 type Anim = {
   chart: Chart<Options>;
@@ -94,7 +95,7 @@ export default class Animator {
 
   next(timestamp: number) {
     this.anims.forEach((anim) => {
-      if (anim.start === null) {
+      if (isNull(anim.start)) {
         anim.start = timestamp;
       }
 
@@ -105,13 +106,9 @@ export default class Animator {
         configurable: true,
       });
 
-      anim.current = Math.min((timestamp - anim.start) / anim.duration, 1);
-
+      anim.current = anim.duration ? Math.min((timestamp - anim.start) / anim.duration, 1) : 1;
       anim.onFrame(anim.current);
-
-      if (anim.current >= 1) {
-        anim.completed = true;
-      }
+      anim.completed = anim.current === 1;
     });
 
     this.anims.forEach((anim) => {

--- a/src/charts/chart.ts
+++ b/src/charts/chart.ts
@@ -40,18 +40,14 @@ export default abstract class Chart<T extends Options> {
   private getAnimationDuration(options: Options) {
     const { firstRendering } = this.animator;
     const animationOption = options.series?.animation;
-    let duration = DEFAULT_ANIM_DURATION;
+    let duration;
 
-    if (!firstRendering) {
-      return duration;
-    }
-
-    if (!isUndefined(animationOption)) {
-      if (isBoolean(animationOption)) {
-        duration = animationOption ? DEFAULT_ANIM_DURATION : 0;
-      } else if (isNumber(animationOption.duration)) {
-        duration = animationOption.duration;
-      }
+    if (!firstRendering || isUndefined(animationOption)) {
+      duration = DEFAULT_ANIM_DURATION;
+    } else if (isBoolean(animationOption)) {
+      duration = animationOption ? DEFAULT_ANIM_DURATION : 0;
+    } else if (isNumber(animationOption.duration)) {
+      duration = animationOption.duration;
     }
 
     return duration;

--- a/src/charts/chart.ts
+++ b/src/charts/chart.ts
@@ -8,11 +8,13 @@ import EventEmitter from '@src/eventEmitter';
 import ComponentManager from '@src/component/componentManager';
 import Painter from '@src/painter';
 import Animator from '@src/animator';
-import { debounce } from '@src/helpers/utils';
+import { debounce, isBoolean, isNumber, isUndefined } from '@src/helpers/utils';
 import { ChartProps } from '@t/options';
 import { responderDetectors } from '@src/responderDetectors';
 import { Options, StoreModule } from '@t/store/store';
 import Component from '@src/component/component';
+
+export const DEFAULT_ANIM_DURATION = 1000;
 
 export default abstract class Chart<T extends Options> {
   store: Store<T>;
@@ -34,6 +36,26 @@ export default abstract class Chart<T extends Options> {
   modules?: StoreModule[];
 
   enteredComponents: Component[] = [];
+
+  private getAnimationDuration(options: Options) {
+    const { firstRendering } = this.animator;
+    const animationOption = options.series?.animation;
+    let duration = DEFAULT_ANIM_DURATION;
+
+    if (!firstRendering) {
+      return duration;
+    }
+
+    if (!isUndefined(animationOption)) {
+      if (isBoolean(animationOption)) {
+        duration = animationOption ? DEFAULT_ANIM_DURATION : 0;
+      } else if (isNumber(animationOption.duration)) {
+        duration = animationOption.duration;
+      }
+    }
+
+    return duration;
+  }
 
   constructor(props: ChartProps<T>) {
     const { el, options, series, categories } = props;
@@ -63,7 +85,7 @@ export default abstract class Chart<T extends Options> {
             this.eventBus.emit('loopComplete');
           },
           chart: this,
-          duration: 1000,
+          duration: this.getAnimationDuration(options),
           requester: this,
         });
       }, 10)

--- a/stories/line.stories.ts
+++ b/stories/line.stories.ts
@@ -210,3 +210,21 @@ export const coordinateZoomable = () => {
 
   return el;
 };
+
+export const animationDuration = () => {
+  const { el } = createChart(temperatureData, {
+    series: {
+      animation: {
+        duration: number('duration', 700, {
+          range: true,
+          min: 0,
+          max: 3000,
+          step: 100,
+        }),
+      },
+      zoomable: true,
+    },
+  });
+
+  return el;
+};

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -169,6 +169,7 @@ interface CircleLegendOptions {
 interface BaseSeriesOptions {
   allowSelect?: boolean;
   dataLabels?: DataLabels;
+  animation?: boolean | { duration: number };
 }
 
 interface LineTypeSeriesOptions extends BaseSeriesOptions {


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [ ] It's submitted to right branch according to our branching model
- [ ] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

```ts
const options = {
  series: {
    animation: boolean | { duration: number } 
  }
}
```

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨