### PR TITLE
fix: resolve selected boxPlot series

### DIFF
--- a/src/component/boxPlotSeries.ts
+++ b/src/component/boxPlotSeries.ts
@@ -182,6 +182,7 @@ export default class BoxPlotSeries extends Component {
     return {
       ...hoveredModel,
       ...point,
+      color: getRGBA(hoveredModel.color, 1),
     };
   }
 
@@ -227,7 +228,11 @@ export default class BoxPlotSeries extends Component {
         models = responders;
       }
 
-      this.eventBus.emit('renderSelectedSeries', { models, name: this.name });
+      this.eventBus.emit('renderSelectedSeries', {
+        models,
+        name: this.name,
+        eventDetectType: this.eventDetectType,
+      });
       this.eventBus.emit('needDraw');
     }
   }

--- a/src/component/selectedSeries.ts
+++ b/src/component/selectedSeries.ts
@@ -16,6 +16,7 @@ import {
   isClickSameGroupedRectResponder,
   isClickSameLabelResponder,
   isClickSameNameResponder,
+  isClickSameTypeDataResponder,
 } from '@src/helpers/responders';
 import { includes } from '@src/helpers/utils';
 import { TooltipModelName } from '@t/components/tooltip';
@@ -78,10 +79,16 @@ export default class SelectedSeries extends Component {
               this.models[name] as RectResponderModel[]
             );
       case 'boxPlot':
-        return isClickSameDataResponder<BoxPlotResponderModel>(
-          models as BoxPlotResponderModel[],
-          this.models[name] as BoxPlotResponderModel[]
-        );
+        return eventDetectType === 'grouped'
+          ? isClickSameDataResponder<BoxPlotResponderModel>(
+              models as BoxPlotResponderModel[],
+              this.models[name] as BoxPlotResponderModel[]
+            )
+          : isClickSameTypeDataResponder(
+              models as BoxPlotResponderModel[],
+              this.models[name] as BoxPlotResponderModel[]
+            );
+
       case 'treemap':
         return isClickSameLabelResponder(
           models as TreemapRectResponderModel[],

--- a/src/component/selectedSeries.ts
+++ b/src/component/selectedSeries.ts
@@ -16,7 +16,7 @@ import {
   isClickSameGroupedRectResponder,
   isClickSameLabelResponder,
   isClickSameNameResponder,
-  isClickSameTypeDataResponder,
+  isClickSameBoxPlotDataResponder,
 } from '@src/helpers/responders';
 import { includes } from '@src/helpers/utils';
 import { TooltipModelName } from '@t/components/tooltip';
@@ -84,11 +84,10 @@ export default class SelectedSeries extends Component {
               models as BoxPlotResponderModel[],
               this.models[name] as BoxPlotResponderModel[]
             )
-          : isClickSameTypeDataResponder(
+          : isClickSameBoxPlotDataResponder(
               models as BoxPlotResponderModel[],
               this.models[name] as BoxPlotResponderModel[]
             );
-
       case 'treemap':
         return isClickSameLabelResponder(
           models as TreemapRectResponderModel[],

--- a/src/helpers/responders.ts
+++ b/src/helpers/responders.ts
@@ -172,16 +172,17 @@ export function isClickSameGroupedRectResponder(
   return same;
 }
 
-export function isClickSameTypeDataResponder(
+export function isClickSameBoxPlotDataResponder(
   responders: BoxPlotResponderModel[],
   selectedSeries?: BoxPlotResponderModel[]
 ) {
   let same = false;
   if (responders.length && selectedSeries?.length) {
+    const { type, data } = responders[0];
     same =
-      responders[0].type === selectedSeries[0].type &&
-      responders[0].data?.label === selectedSeries[0].data?.label &&
-      responders[0].data?.category === selectedSeries[0].data?.category;
+      type === selectedSeries[0].type &&
+      data?.label === selectedSeries[0].data?.label &&
+      data?.category === selectedSeries[0].data?.category;
   }
 
   return same;

--- a/src/helpers/responders.ts
+++ b/src/helpers/responders.ts
@@ -171,3 +171,18 @@ export function isClickSameGroupedRectResponder(
 
   return same;
 }
+
+export function isClickSameTypeDataResponder(
+  responders: BoxPlotResponderModel[],
+  selectedSeries?: BoxPlotResponderModel[]
+) {
+  let same = false;
+  if (responders.length && selectedSeries?.length) {
+    same =
+      responders[0].type === selectedSeries[0].type &&
+      responders[0].data?.label === selectedSeries[0].data?.label &&
+      responders[0].data?.category === selectedSeries[0].data?.category;
+  }
+
+  return same;
+}


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [ ] It's submitted to right branch according to our branching model
- [ ] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description
* When the event detection type is `grouped`, the previously set inactive color value is set when clicking another model.

| AS-IS | TO-BE |
| --- | --- |
| ![스크린샷 2020-10-19 15 16 05](https://user-images.githubusercontent.com/43128697/96408315-31473080-121e-11eb-8a37-aa5a08abced2.png) | <img width="918" alt="스크린샷 2020-10-19 15 16 25" src="https://user-images.githubusercontent.com/43128697/96408331-36a47b00-121e-11eb-8ed8-82f6dcef1e65.png"> |

* When the event detection type is `point`, If the event detection type is 'point',
Add logic to check if the same model is clicked.
---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨