### PR TITLE
feat: add formatter for data labels of stack total

### DIFF
--- a/src/helpers/dataLabels.ts
+++ b/src/helpers/dataLabels.ts
@@ -3,7 +3,7 @@ import { isFunction, includes, isBoolean, isString } from '@src/helpers/utils';
 import {
   DataLabelAnchor,
   SeriesDataType,
-  SubDataLabel,
+  StackTotalDataLabel,
   DataLabelOptions,
   PieDataLabels,
   BoxDataLabels,
@@ -92,8 +92,9 @@ export function getDefaultDataLabelsOptions(
   if (withStack) {
     const stackTotal = (dataLabelOptions as BoxDataLabels).stackTotal;
     options.stackTotal = {
-      visible: isBoolean(stackTotal?.visible) ? stackTotal?.visible : true,
-    } as Required<SubDataLabel>;
+      visible: isBoolean(stackTotal?.visible) ? stackTotal!.visible : true,
+      formatter: isFunction(stackTotal?.formatter) ? stackTotal!.formatter! : formatter,
+    } as Required<StackTotalDataLabel>;
   }
 
   if (type === 'sector' && (dataLabelOptions as PieDataLabels).pieSeriesName?.visible) {
@@ -409,11 +410,13 @@ export function makeRectLabelInfo(
   dataLabelOptions: DataLabelOption
 ): DataLabel {
   const { type, value, direction, name, theme } = rect;
-  const { formatter } = dataLabelOptions;
   const horizontal = isHorizontal(direction);
   const labelPosition = horizontal
     ? makeHorizontalRectLabelInfo(rect, dataLabelOptions)
     : makeVerticalRectLabelInfo(rect, dataLabelOptions);
+
+  const formatter =
+    type === 'stackTotal' ? dataLabelOptions.stackTotal!.formatter : dataLabelOptions.formatter;
 
   return {
     type: type,

--- a/stories/bar.stack.stories.ts
+++ b/stories/bar.stack.stories.ts
@@ -182,9 +182,11 @@ export const dataLabelsWithStackTotal = () => {
       stack: true,
       dataLabels: {
         visible: true,
+        formatter: (value) => `$${value}`,
         anchor: 'center',
         stackTotal: {
           visible: true,
+          formatter: (value) => `Total $${value}`,
         },
       },
     },

--- a/stories/column.stack.stories.ts
+++ b/stories/column.stack.stories.ts
@@ -207,9 +207,11 @@ export const dataLabelsWithStackTotal = () => {
       stack: true,
       dataLabels: {
         visible: true,
+        formatter: (value) => `$${value}`,
         anchor: 'center',
         stackTotal: {
           visible: true,
+          formatter: (value) => `Total $${value}`,
         },
       },
     },

--- a/types/components/dataLabels.d.ts
+++ b/types/components/dataLabels.d.ts
@@ -2,7 +2,7 @@ import {
   Point,
   DataLabelOptions,
   DataLabelPieSeriesName,
-  SubDataLabel,
+  StackTotalDataLabel,
   BoxSeriesDataType,
 } from '@t/options';
 import { PointModel, SectorModel, RectModel, Nullable } from './series';
@@ -43,7 +43,7 @@ export type DataLabel = {
 export type DataLabelOption = Required<
   Pick<DataLabelOptions, 'anchor' | 'offsetX' | 'offsetY' | 'formatter'>
 > & {
-  stackTotal?: Required<SubDataLabel>;
+  stackTotal?: Required<StackTotalDataLabel>;
   pieSeriesName?: DataLabelPieSeriesName;
 };
 

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -528,8 +528,9 @@ export type SeriesDataType =
 
 export type DataLabelAnchor = 'center' | 'start' | 'end' | 'auto' | 'outer';
 
-export type SubDataLabel = {
+export type StackTotalDataLabel = {
   visible?: boolean;
+  formatter?: Formatter;
 };
 
 export type DataLabelPieSeriesName = {
@@ -546,7 +547,7 @@ export type DataLabelOptions = {
 };
 
 export interface BoxDataLabels extends DataLabelOptions {
-  stackTotal?: SubDataLabel;
+  stackTotal?: StackTotalDataLabel;
 }
 export interface PieDataLabels extends DataLabelOptions {
   pieSeriesName?: DataLabelPieSeriesName;


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [ ] It's submitted to right branch according to our branching model
- [ ] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description
```ts
const options = {
  ...
  series: {
    stack: true,
    dataLabels: {
      visible: true,
      formatter: (value) => `$${value}`,
      anchor: 'center',
      stackTotal: {
        visible: true,
        formatter: (value) => `Total $${value}`,
      },
    },
  },
};
```

<img width="995" alt="스크린샷 2020-12-08 14 56 01" src="https://user-images.githubusercontent.com/43128697/101447041-c7b6e900-3967-11eb-8518-ee5a89c16fb1.png">

<img width="994" alt="스크린샷 2020-12-08 14 56 25" src="https://user-images.githubusercontent.com/43128697/101447046-ca194300-3967-11eb-8b39-189522f94ed5.png">

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨