### PR TITLE
Fix/improvement pie radius with outer data labels

### DIFF
--- a/apps/chart/src/helpers/dataLabels.ts
+++ b/apps/chart/src/helpers/dataLabels.ts
@@ -30,7 +30,7 @@ import {
 import { Nullable } from '@t/components/series';
 import { getFont } from './style';
 
-const RADIUS_PADDING = 30;
+export const RADIUS_PADDING = 30;
 const CALLOUT_LENGTH = 20;
 
 type LabelPosition = {

--- a/apps/chart/src/helpers/pieSeries.ts
+++ b/apps/chart/src/helpers/pieSeries.ts
@@ -2,7 +2,6 @@ import { getPercentageValue, isString, isNull } from './utils';
 import { Rect, PieSeriesType, NestedPieSeriesType, PieDataLabels } from '@t/options';
 import { TooltipData } from '@t/components/tooltip';
 import { RawSeries, OptionsWithDataLabels } from '@t/store/store';
-import Tooltip from '@src/component/tooltip';
 
 const DEFAULT_RADIUS_RATIO = 0.9;
 const semiCircleCenterYRatio = {
@@ -46,11 +45,23 @@ export function isSemiCircle(clockwise: boolean, startAngle: number, endAngle: n
   );
 }
 
-export function getDefaultRadius({ width, height }: Rect, isSemiCircular = false) {
-  return (
-    (isSemiCircular ? Math.min(width / 2, height) : Math.min(width, height) / 2) *
-    DEFAULT_RADIUS_RATIO
-  );
+export function getDefaultRadius(
+  { width, height }: Rect,
+  isSemiCircular = false,
+  maxDataLabelWidth = 0,
+  maxDataLabelHeight = 0
+) {
+  let result;
+
+  if (isSemiCircular) {
+    result = Math.min(width / 2, height) - maxDataLabelHeight;
+  } else if (width > height) {
+    result = height / 2 - maxDataLabelHeight;
+  } else {
+    result = width / 2 - maxDataLabelWidth;
+  }
+
+  return Math.max(result, 10);
 }
 
 export function getSemiCircleCenterY(rectHeight: number, clockwise: boolean) {

--- a/apps/chart/src/helpers/pieSeries.ts
+++ b/apps/chart/src/helpers/pieSeries.ts
@@ -3,11 +3,12 @@ import { Rect, PieSeriesType, NestedPieSeriesType, PieDataLabels } from '@t/opti
 import { TooltipData } from '@t/components/tooltip';
 import { RawSeries, OptionsWithDataLabels } from '@t/store/store';
 
-const DEFAULT_RADIUS_RATIO = 0.9;
 const semiCircleCenterYRatio = {
   COUNTER_CLOCKWISE: 0.1,
   CLOCKWISE: 1,
 };
+
+const MINIMUM_RADIUS = 10;
 
 export function hasClockwiseSemiCircle(clockwise: boolean, startAngle: number, endAngle: number) {
   return (
@@ -61,7 +62,7 @@ export function getDefaultRadius(
     result = width / 2 - maxDataLabelWidth;
   }
 
-  return Math.max(result, 10);
+  return Math.max(result, MINIMUM_RADIUS);
 }
 
 export function getSemiCircleCenterY(rectHeight: number, clockwise: boolean) {

--- a/apps/chart/src/helpers/theme.ts
+++ b/apps/chart/src/helpers/theme.ts
@@ -39,7 +39,7 @@ const boxplotDefault = {
 };
 
 export const DEFAULT_BULLET_RANGE_OPACITY = [0.5, 0.3, 0.1];
-const DEFAULT_PIE_LINE_WIDTH = 5;
+const DEFAULT_PIE_LINE_WIDTH = 3;
 
 const DEFAULT_DATA_LABEL = {
   fontFamily: 'Arial',

--- a/apps/chart/stories/nestedPie.stories.ts
+++ b/apps/chart/stories/nestedPie.stories.ts
@@ -146,8 +146,9 @@ export const dataLabels = () => {
         },
         dataLabels: {
           visible: true,
+          anchor: 'outer',
           pieSeriesName: {
-            visible: true,
+            visible: false,
             anchor: 'outer',
           },
         },

--- a/apps/chart/tests/components/pieSeries.spec.ts
+++ b/apps/chart/tests/components/pieSeries.spec.ts
@@ -63,6 +63,18 @@ const chartState = {
           },
           areaOpacity: 1,
         },
+        dataLabels: {
+          fontFamily: 'Arial',
+          fontSize: 11,
+          fontWeight: 400,
+          color: '#333333',
+          pieSeriesName: {
+            fontFamily: 'Arial',
+            fontSize: 11,
+            fontWeight: 400,
+            color: '#333333',
+          },
+        },
       },
     },
   },

--- a/apps/chart/tests/components/pieSeries.spec.ts
+++ b/apps/chart/tests/components/pieSeries.spec.ts
@@ -84,20 +84,9 @@ describe('basic', () => {
         {
           color: 'rgba(0, 169, 255, 1)',
           name: 'A',
-          radius: {
-            inner: 0,
-            outer: 45,
-          },
-          degree: {
-            start: 0,
-            end: 180,
-          },
-          style: [
-            {
-              lineWidth: 0,
-              strokeStyle: 'rgba(0, 0, 0, 0)',
-            },
-          ],
+          radius: { inner: 0, outer: 50 },
+          degree: { start: 0, end: 180 },
+          style: [{ lineWidth: 0, strokeStyle: 'rgba(0, 0, 0, 0)' }],
           type: 'sector',
           value: 50,
           x: 50,
@@ -110,20 +99,9 @@ describe('basic', () => {
         {
           color: 'rgba(255, 184, 64, 1)',
           name: 'B',
-          radius: {
-            inner: 0,
-            outer: 45,
-          },
-          degree: {
-            start: 180,
-            end: 360,
-          },
-          style: [
-            {
-              lineWidth: 0,
-              strokeStyle: 'rgba(0, 0, 0, 0)',
-            },
-          ],
+          radius: { inner: 0, outer: 50 },
+          degree: { start: 180, end: 360 },
+          style: [{ lineWidth: 0, strokeStyle: 'rgba(0, 0, 0, 0)' }],
           type: 'sector',
           value: 50,
           x: 50,
@@ -143,23 +121,12 @@ describe('basic', () => {
         color: 'rgba(0, 169, 255, 1)',
         x: 50,
         y: 50,
-        radius: {
-          inner: 0,
-          outer: 45,
-        },
-        degree: {
-          start: 0,
-          end: 180,
-        },
+        radius: { inner: 0, outer: 50 },
+        degree: { start: 0, end: 180 },
         value: 50,
         clockwise: true,
         drawingStartAngle: -90,
-        style: [
-          {
-            lineWidth: 0,
-            strokeStyle: 'rgba(0, 0, 0, 0)',
-          },
-        ],
+        style: [{ lineWidth: 0, strokeStyle: 'rgba(0, 0, 0, 0)' }],
         seriesIndex: 0,
         data: {
           label: 'A',
@@ -178,23 +145,12 @@ describe('basic', () => {
         color: 'rgba(255, 184, 64, 1)',
         x: 50,
         y: 50,
-        radius: {
-          inner: 0,
-          outer: 45,
-        },
-        degree: {
-          start: 180,
-          end: 360,
-        },
+        radius: { inner: 0, outer: 50 },
+        degree: { start: 180, end: 360 },
         value: 50,
         clockwise: true,
         drawingStartAngle: -90,
-        style: [
-          {
-            lineWidth: 0,
-            strokeStyle: 'rgba(0, 0, 0, 0)',
-          },
-        ],
+        style: [{ lineWidth: 0, strokeStyle: 'rgba(0, 0, 0, 0)' }],
         seriesIndex: 1,
         data: {
           label: 'B',
@@ -229,20 +185,9 @@ describe('basic', () => {
         color: 'rgba(0, 169, 255, 1)',
         name: 'A',
         drawingStartAngle: -90,
-        radius: {
-          inner: 0,
-          outer: 45,
-        },
-        degree: {
-          start: 360,
-          end: 180,
-        },
-        style: [
-          {
-            lineWidth: 0,
-            strokeStyle: 'rgba(0, 0, 0, 0)',
-          },
-        ],
+        radius: { inner: 0, outer: 50 },
+        degree: { start: 360, end: 180 },
+        style: [{ lineWidth: 0, strokeStyle: 'rgba(0, 0, 0, 0)' }],
         type: 'sector',
         value: 50,
         x: 50,
@@ -255,20 +200,9 @@ describe('basic', () => {
         color: 'rgba(255, 184, 64, 1)',
         name: 'B',
         drawingStartAngle: -90,
-        radius: {
-          inner: 0,
-          outer: 45,
-        },
-        degree: {
-          start: 180,
-          end: 0,
-        },
-        style: [
-          {
-            lineWidth: 0,
-            strokeStyle: 'rgba(0, 0, 0, 0)',
-          },
-        ],
+        radius: { inner: 0, outer: 50 },
+        degree: { start: 180, end: 0 },
+        style: [{ lineWidth: 0, strokeStyle: 'rgba(0, 0, 0, 0)' }],
         type: 'sector',
         value: 50,
         x: 50,
@@ -301,7 +235,7 @@ describe('basic', () => {
       {
         color: 'rgba(204, 204, 204, 1)',
         name: 'A',
-        radius: { inner: 0, outer: 45 },
+        radius: { inner: 0, outer: 50 },
         degree: { start: 0, end: 180 },
         style: [{ lineWidth: 0, strokeStyle: 'rgba(0, 0, 0, 0)' }],
         type: 'sector',
@@ -316,7 +250,7 @@ describe('basic', () => {
       {
         color: 'rgba(170, 170, 170, 1)',
         name: 'C',
-        radius: { inner: 0, outer: 45 },
+        radius: { inner: 0, outer: 50 },
         degree: { start: 180, end: 288 },
         style: [{ lineWidth: 0, strokeStyle: 'rgba(0, 0, 0, 0)' }],
         type: 'sector',
@@ -331,7 +265,7 @@ describe('basic', () => {
       {
         color: 'rgba(187, 187, 187, 1)',
         name: 'D',
-        radius: { inner: 0, outer: 45 },
+        radius: { inner: 0, outer: 50 },
         degree: { start: 288, end: 360 },
         style: [{ lineWidth: 0, strokeStyle: 'rgba(0, 0, 0, 0)' }],
         type: 'sector',
@@ -376,20 +310,9 @@ describe('donut', () => {
         {
           color: 'rgba(0, 169, 255, 1)',
           name: 'A',
-          radius: {
-            inner: 18,
-            outer: 45,
-          },
-          degree: {
-            start: 0,
-            end: 180,
-          },
-          style: [
-            {
-              lineWidth: 0,
-              strokeStyle: 'rgba(0, 0, 0, 0)',
-            },
-          ],
+          radius: { inner: 20, outer: 50 },
+          degree: { start: 0, end: 180 },
+          style: [{ lineWidth: 0, strokeStyle: 'rgba(0, 0, 0, 0)' }],
           type: 'sector',
           value: 50,
           x: 50,
@@ -402,20 +325,9 @@ describe('donut', () => {
         {
           color: 'rgba(255, 184, 64, 1)',
           name: 'B',
-          radius: {
-            inner: 18,
-            outer: 45,
-          },
-          degree: {
-            start: 180,
-            end: 360,
-          },
-          style: [
-            {
-              lineWidth: 0,
-              strokeStyle: 'rgba(0, 0, 0, 0)',
-            },
-          ],
+          radius: { inner: 20, outer: 50 },
+          degree: { start: 180, end: 360 },
+          style: [{ lineWidth: 0, strokeStyle: 'rgba(0, 0, 0, 0)' }],
           type: 'sector',
           value: 50,
           x: 50,
@@ -435,23 +347,12 @@ describe('donut', () => {
         color: 'rgba(0, 169, 255, 1)',
         x: 50,
         y: 50,
-        radius: {
-          inner: 18,
-          outer: 45,
-        },
-        degree: {
-          start: 0,
-          end: 180,
-        },
+        radius: { inner: 20, outer: 50 },
+        degree: { start: 0, end: 180 },
         value: 50,
         clockwise: true,
         drawingStartAngle: -90,
-        style: [
-          {
-            lineWidth: 0,
-            strokeStyle: 'rgba(0, 0, 0, 0)',
-          },
-        ],
+        style: [{ lineWidth: 0, strokeStyle: 'rgba(0, 0, 0, 0)' }],
         seriesIndex: 0,
         data: {
           label: 'A',
@@ -470,23 +371,12 @@ describe('donut', () => {
         color: 'rgba(255, 184, 64, 1)',
         x: 50,
         y: 50,
-        radius: {
-          inner: 18,
-          outer: 45,
-        },
-        degree: {
-          start: 180,
-          end: 360,
-        },
+        radius: { inner: 20, outer: 50 },
+        degree: { start: 180, end: 360 },
         value: 50,
         clockwise: true,
         drawingStartAngle: -90,
-        style: [
-          {
-            lineWidth: 0,
-            strokeStyle: 'rgba(0, 0, 0, 0)',
-          },
-        ],
+        style: [{ lineWidth: 0, strokeStyle: 'rgba(0, 0, 0, 0)' }],
         seriesIndex: 1,
         data: {
           label: 'B',
@@ -531,15 +421,10 @@ describe('donut', () => {
           clockwise: true,
           color: 'rgba(0, 169, 255, 1)',
           name: 'A',
-          radius: { inner: 0, outer: 45 },
+          radius: { inner: 0, outer: 50 },
           degree: { start: 0, end: 90 },
           drawingStartAngle: -180,
-          style: [
-            {
-              lineWidth: 0,
-              strokeStyle: 'rgba(0, 0, 0, 0)',
-            },
-          ],
+          style: [{ lineWidth: 0, strokeStyle: 'rgba(0, 0, 0, 0)' }],
           type: 'sector',
           value: 50,
           x: 50,
@@ -551,15 +436,10 @@ describe('donut', () => {
           clockwise: true,
           color: 'rgba(255, 184, 64, 1)',
           name: 'B',
-          radius: { inner: 0, outer: 45 },
+          radius: { inner: 0, outer: 50 },
           degree: { start: 90, end: 180 },
           drawingStartAngle: -180,
-          style: [
-            {
-              lineWidth: 0,
-              strokeStyle: 'rgba(0, 0, 0, 0)',
-            },
-          ],
+          style: [{ lineWidth: 0, strokeStyle: 'rgba(0, 0, 0, 0)' }],
           type: 'sector',
           value: 50,
           x: 50,

--- a/apps/chart/tests/store/theme.spec.ts
+++ b/apps/chart/tests/store/theme.spec.ts
@@ -1018,7 +1018,7 @@ describe('theme store', () => {
                 areaOpacity: 1,
                 colors: ['#00a9ff', '#ffb840'],
                 hover: {
-                  lineWidth: 5,
+                  lineWidth: 3,
                   shadowBlur: 5,
                   shadowColor: '#cccccc',
                   shadowOffsetX: 0,
@@ -1028,7 +1028,7 @@ describe('theme store', () => {
                 lineWidth: 1,
                 select: {
                   areaOpacity: 1,
-                  lineWidth: 5,
+                  lineWidth: 3,
                   restSeries: {
                     areaOpacity: 0.3,
                   },
@@ -1083,7 +1083,7 @@ describe('theme store', () => {
                 areaOpacity: 1,
                 colors: ['#ff5a46', '#00bd9f', '#785fff'],
                 hover: {
-                  lineWidth: 5,
+                  lineWidth: 3,
                   shadowBlur: 5,
                   shadowColor: '#cccccc',
                   shadowOffsetX: 0,
@@ -1093,7 +1093,7 @@ describe('theme store', () => {
                 lineWidth: 1,
                 select: {
                   areaOpacity: 1,
-                  lineWidth: 5,
+                  lineWidth: 3,
                   restSeries: {
                     areaOpacity: 0.3,
                   },
@@ -1167,7 +1167,7 @@ describe('theme store', () => {
               areaOpacity: 1,
               colors: ['#aaaaaa', '#bbbbbb'],
               hover: {
-                lineWidth: 5,
+                lineWidth: 3,
                 shadowBlur: 5,
                 shadowColor: '#cccccc',
                 shadowOffsetX: 0,
@@ -1177,7 +1177,7 @@ describe('theme store', () => {
               lineWidth: 1,
               select: {
                 areaOpacity: 1,
-                lineWidth: 5,
+                lineWidth: 3,
                 restSeries: {
                   areaOpacity: 0.3,
                 },
@@ -1232,7 +1232,7 @@ describe('theme store', () => {
               areaOpacity: 1,
               colors: ['#cccccc', '#dddddd', '#eeeeee'],
               hover: {
-                lineWidth: 5,
+                lineWidth: 3,
                 shadowBlur: 5,
                 shadowColor: '#cccccc',
                 shadowOffsetX: 0,
@@ -1242,7 +1242,7 @@ describe('theme store', () => {
               lineWidth: 1,
               select: {
                 areaOpacity: 1,
-                lineWidth: 5,
+                lineWidth: 3,
                 restSeries: {
                   areaOpacity: 0.3,
                 },
@@ -1320,7 +1320,7 @@ describe('theme store', () => {
               areaOpacity: 1,
               colors: ['#aaaaaa', '#bbbbbb'],
               hover: {
-                lineWidth: 5,
+                lineWidth: 3,
                 shadowBlur: 5,
                 shadowColor: '#cccccc',
                 shadowOffsetX: 0,
@@ -1330,7 +1330,7 @@ describe('theme store', () => {
               lineWidth: 1,
               select: {
                 areaOpacity: 1,
-                lineWidth: 5,
+                lineWidth: 3,
                 restSeries: {
                   areaOpacity: 0.3,
                 },
@@ -1385,7 +1385,7 @@ describe('theme store', () => {
               areaOpacity: 1,
               colors: ['#cccccc', '#dddddd', '#eeeeee'],
               hover: {
-                lineWidth: 5,
+                lineWidth: 3,
                 shadowBlur: 5,
                 shadowColor: '#cccccc',
                 shadowOffsetX: 0,
@@ -1395,7 +1395,7 @@ describe('theme store', () => {
               lineWidth: 1,
               select: {
                 areaOpacity: 1,
-                lineWidth: 5,
+                lineWidth: 3,
                 restSeries: {
                   areaOpacity: 0.3,
                 },


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [ ] It's submitted to right branch according to our branching model
- [ ] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description
* When calculating the radius of the pie chart, it is affected by the outer data label. (using `anchor: 'outer'`)
* The minimum radius is `10`.
* Changed the `lineWidth` of the pie series to `3` on hover or on selection.
<img width="661" alt="스크린샷 2021-01-21 23 14 07" src="https://user-images.githubusercontent.com/43128697/105362602-6e1c2c80-5c3e-11eb-9e56-4cdc80e63871.png">

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨