### PR TITLE
fix: check data and remove options when setData

### DIFF
--- a/src/js/charts/lineChart.js
+++ b/src/js/charts/lineChart.js
@@ -46,13 +46,23 @@ class LineChart extends ChartBase {
      */
     this.Series = Series;
 
-    if (this.dataProcessor.isCoordinateType()) {
+    if (rawData.series.line.length && this.dataProcessor.isCoordinateType()) {
       delete this.options.xAxis.tickInterval;
       this.options.tooltip.grouped = false;
       this.options.series.shifting = false;
     }
 
     this._dynamicDataHelper = new DynamicDataHelper(this);
+  }
+
+  setData(rawData = {}, animation = true) {
+    if (rawData.series.length && !rawData.categories.length) {
+      delete this.options.xAxis.tickInterval;
+      this.options.tooltip.grouped = false;
+      this.options.series.shifting = false;
+    }
+
+    super.setData(rawData, animation);
   }
 
   /**


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [ ] It's submitted to right branch according to our branching model
- [ ] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

#### before
![image](https://user-images.githubusercontent.com/35371660/106219903-b5e21b80-621d-11eb-8f54-aef99f4d8886.png)

`tickInterval: 'auto'` options is not working when `setData` using empty data is entered at the first rendering

#### after
![image](https://user-images.githubusercontent.com/35371660/106220029-f8a3f380-621d-11eb-8683-be0f9f0e2382.png)




---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
