### PR TITLE
chore: show canvas unsupported feature warning only once

### DIFF
--- a/apps/chart/src/helpers/style.ts
+++ b/apps/chart/src/helpers/style.ts
@@ -36,8 +36,6 @@ export function getFont(theme: BubbleDataLabel | BoxDataLabel) {
 export function setLineDash(ctx: CanvasRenderingContext2D, dashSegments: number[]) {
   if (ctx.setLineDash) {
     ctx.setLineDash(dashSegments);
-  } else {
-    console.error(message.DASH_SEGMENTS_UNAVAILABLE_ERROR);
   }
 }
 

--- a/apps/chart/src/painter.ts
+++ b/apps/chart/src/painter.ts
@@ -35,6 +35,12 @@ export default class Painter {
     this.chart = chart;
   }
 
+  showUnsupportedCanvasFeatureError() {
+    if (!this.ctx.setLineDash) {
+      console.warn(message.DASH_SEGMENTS_UNAVAILABLE_ERROR);
+    }
+  }
+
   setup() {
     const { height, width } = this.chart.store.state.chart;
 
@@ -60,6 +66,7 @@ export default class Painter {
     }
 
     this.setSize(width, height);
+    this.showUnsupportedCanvasFeatureError();
   }
 
   setSize(width: number, height: number) {


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [ ] It's submitted to right branch according to our branching model
- [ ] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

#### before

![image](https://user-images.githubusercontent.com/35371660/108793654-62b67b00-75c7-11eb-82d2-febc72c704a0.png)

#### after
![image](https://user-images.githubusercontent.com/35371660/108793732-90032900-75c7-11eb-89e3-b17d173c350c.png)

Fix not to show error message continuously

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
