### PR TITLE
docs: fix typo

### DIFF
--- a/docs/en/common-api.md
+++ b/docs/en/common-api.md
@@ -47,7 +47,7 @@ chart.on('selectSeries', (ev) => {
 * Compatible with: `All`
 
 ```ts
-public destory(): void;
+public destroy(): void;
 ```
 
 Destroys the chart instance.

--- a/docs/ko/common-api.md
+++ b/docs/ko/common-api.md
@@ -46,7 +46,7 @@ chart.on('selectSeries', (ev) => {
 * 사용 가능 차트 타입: `All`
 
 ```ts
-public destory(): void;
+public destroy(): void;
 ```
 
 생성된 차트 인스턴스를 제거해준다.


### PR DESCRIPTION
I found a typo(`destory`), so I just fixed it(`destroy`)

![Screen Shot 2021-05-27 at 10 29 12](https://user-images.githubusercontent.com/42969906/119751926-0a995880-bed7-11eb-80ee-744f2bb0c5db.jpg)
