### PR TITLE
docs: fix typo

### DIFF
--- a/docs/en/chart-columnLine.md
+++ b/docs/en/chart-columnLine.md
@@ -180,7 +180,7 @@ type options = {
     };
     line?: {
       selectable?: boolean;
-      spline?: boolena;
+      spline?: boolean;
       showDot?: boolean;
       dataLabels?: {
         visible?: boolean;

--- a/docs/en/chart-lineScatter.md
+++ b/docs/en/chart-lineScatter.md
@@ -165,7 +165,7 @@ type options = {
   series?: {
     selectable?: boolean;
     line?: {
-      spline?: boolena;
+      spline?: boolean;
       showDot?: boolean;
     }
     dataLabels?: {

--- a/docs/ko/chart-columnLine.md
+++ b/docs/ko/chart-columnLine.md
@@ -178,7 +178,7 @@ type options = {
     };
     line?: {
       selectable?: boolean;
-      spline?: boolena;
+      spline?: boolean;
       showDot?: boolean;
       dataLabels?: {
         visible?: boolean;

--- a/docs/ko/chart-lineScatter.md
+++ b/docs/ko/chart-lineScatter.md
@@ -164,7 +164,7 @@ type options = {
   series?: {
     selectable?: boolean;
     line?: {
-      spline?: boolena;
+      spline?: boolean;
       showDot?: boolean;
     }
     dataLabels?: {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] The commit message follows our guidelines

### Description
There are miss typos in the chart document with a line.
Change all `boolena` to `boolean` in Charts with line

![image](https://user-images.githubusercontent.com/55948211/199665698-ddaead8c-0a4f-4bb8-ac25-0a9aaa98785a.png)


